### PR TITLE
🐞 fix: Enhance timer mutation with optimistic response for better performance

### DIFF
--- a/src/lib/components/speakersList/chairControls/SpeechControls.svelte
+++ b/src/lib/components/speakersList/chairControls/SpeechControls.svelte
@@ -83,19 +83,42 @@
 		if (!speakersList) return;
 
 		if (otherList?.startTimestamp) {
-			await UpdateSpeakersListTimingsWithOtherListMutation.mutate({
-				speakersListId: speakersList.id,
-				startTimestamp: $serverTime.toDate(),
-				otherListId: otherList.id,
-				otherListStopTimer: true,
-				otherListTimeLeft:
-					otherList.type === 'SPEAKERS_LIST' ? speakersList.speakingTime : otherList.speakingTime
-			});
+			await UpdateSpeakersListTimingsWithOtherListMutation.mutate(
+				{
+					speakersListId: speakersList.id,
+					startTimestamp: $serverTime.toDate(),
+					otherListId: otherList.id,
+					otherListStopTimer: true,
+					otherListTimeLeft:
+						otherList.type === 'SPEAKERS_LIST' ? speakersList.speakingTime : otherList.speakingTime
+				},
+				{
+					optimisticResponse: {
+						MainUpdateSpeakersList: {
+							speakingTime: speakersList.speakingTime,
+							startTimestamp: $serverTime.toDate()
+						},
+						OtherUpdateSpeakersList: {
+							speakingTime: otherList.speakingTime
+						}
+					}
+				}
+			);
 		} else {
-			await UpdateSpeakersListTimingsMutation.mutate({
-				speakersListId: speakersList.id,
-				startTimestamp: $serverTime.toDate()
-			});
+			await UpdateSpeakersListTimingsMutation.mutate(
+				{
+					speakersListId: speakersList.id,
+					startTimestamp: $serverTime.toDate()
+				},
+				{
+					optimisticResponse: {
+						updateSpeakersList: {
+							speakingTime: speakersList.speakingTime,
+							startTimestamp: $serverTime.toDate()
+						}
+					}
+				}
+			);
 		}
 	};
 


### PR DESCRIPTION
This pull request enhances the functionality of the `SpeechControls` component in `SpeechControls.svelte` by introducing optimistic updates to improve the user experience during mutation operations.

### Enhancements to mutation operations:

* Added `optimisticResponse` to the `UpdateSpeakersListTimingsWithOtherListMutation` to provide immediate feedback by simulating the expected server response. This includes updates to `speakingTime` and `startTimestamp` for both the main and other speakers' lists.
* Added `optimisticResponse` to the `UpdateSpeakersListTimingsMutation` to simulate the server response for `speakingTime` and `startTimestamp` updates when no other list is involved.